### PR TITLE
Fix os_name on windows, really remove build

### DIFF
--- a/R/attach.R
+++ b/R/attach.R
@@ -49,7 +49,7 @@ os <- function() {
   # https://github.com/wch/r-source/blob/af7f52f70101960861e5d995d3a4bec010bc89e6/src/library/utils/src/windows/util.c
 
   x <- gsub("Service Pack", "SP", x)
-  x <- gsub(" (build \\d+)", "", x)
+  x <- gsub(" [(]build \\d+[)]", "", x)
 
   x
 }


### PR DESCRIPTION
Need to protect parens in a regex.