### PR TITLE
Fix tidyverse_deps()

### DIFF
--- a/R/update.R
+++ b/R/update.R
@@ -58,7 +58,7 @@ tidyverse_deps <- function(recursive = FALSE) {
   )
   pkg_deps <- setdiff(pkg_deps, base_pkgs)
 
-  cran_version <- lapply(pkgs[pkg_deps, "Version"], package_version)
+  cran_version <- lapply(pkgs[pkg_deps, "Version"], base::package_version)
   local_version <- lapply(pkg_deps, utils::packageVersion)
 
   behind <- purrr::map2_lgl(cran_version, local_version, `>`)


### PR DESCRIPTION
This PR fixes the current `tidyverse_deps()`:
```r
devtools::install_github("tidyverse/tidyverse")
library(tidyverse)
tidyverse_deps()
#> Error in utils::packageVersion(x) : package ‘0.4.2’ not found
```

It is due to commit e87c526354356b23340802a1e08d9ef1075c5819 because the addition of a new helper [package_version](https://github.com/tidyverse/tidyverse/commit/e87c526354356b23340802a1e08d9ef1075c5819#diff-bad55cdd46f463abc12ea0917fb6a1dfR28) conflicts with the `base` function of the [same name](https://github.com/tidyverse/tidyverse/blob/e87c526354356b23340802a1e08d9ef1075c5819/R/update.R#L61).

