### PR TITLE
r-lib/boxes changed to r-lib/cli

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,7 @@ Imports:
     tidyr,
     xml2,
     crayon,
-    boxes
+    cli
 Suggests:
     feather,
     knitr,
@@ -46,5 +46,5 @@ URL: http://tidyverse.tidyverse.org, https://github.com/tidyverse/tidyverse
 BugReports: https://github.com/tidyverse/tidyverse/issues
 VignetteBuilder: knitr
 Remotes: 
-    r-lib/boxes,
+    r-lib/cli,
     gaborcsardi/crayon

--- a/R/utils.R
+++ b/R/utils.R
@@ -17,7 +17,7 @@ rule <- function(..., pad = "-", startup = FALSE) {
   }
   width <- min(getOption("width") - nchar(title) - 1, 68)
 
-  text <- cli::rule(left = title, width = width, line_color = "black")
+  text <- cli::rule(left = title, width = width, line_col = "black")
 
   if (startup) {
     startup_message(text)

--- a/R/utils.R
+++ b/R/utils.R
@@ -17,7 +17,7 @@ rule <- function(..., pad = "-", startup = FALSE) {
   }
   width <- min(getOption("width") - nchar(title) - 1, 68)
 
-  text <- boxes::rule(left = title, width = width, line_color = "black")
+  text <- cli::rule(left = title, width = width, line_color = "black")
 
   if (startup) {
     startup_message(text)


### PR DESCRIPTION
This week r-lib/boxes repo was renamed to r-lib/cli

So references in R/utils.R and DESCRIPTION files should be changed 

And in cli::rule function the argument "line_color" was renamed to "line_col", this also should be reflected in R/utils.R file