### PR TITLE
Fixed parse error of tidyverse package names (close #93)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# tidyverse 1.2.2.9000
+
+* Fixed parse error of tidyverse package names (#93)
+
 # tidyverse 1.2.1
 
 * Require modern versions of all packages (#85)

--- a/R/utils.R
+++ b/R/utils.R
@@ -34,7 +34,7 @@ tidyverse_packages <- function(include_self = TRUE) {
   raw <- utils::packageDescription("tidyverse")$Imports
   imports <- strsplit(raw, ",")[[1]]
   parsed <- gsub("^\\s+|\\s+$", "", imports)
-  names <- vapply(strsplit(parsed, " +"), "[[", 1, FUN.VALUE = character(1))
+  names <- vapply(strsplit(parsed, "\\s+"), "[[", 1, FUN.VALUE = character(1))
 
   if (include_self) {
     names <- c(names, "tidyverse")


### PR DESCRIPTION
Implements the fix by @kent37 in #93 regarding the output of `readxl` being displayed as `readxl\n(>=` instead of the proper name of `readxl` in `tidyverse_packages()`

Making: 

```r
tidyverse::tidyverse_packages()
#>  [1] "broom"       "cli"         "crayon"      "dplyr"       "dbplyr"     
#>  [6] "forcats"     "ggplot2"     "haven"       "hms"         "httr"       
#> [11] "jsonlite"    "lubridate"   "magrittr"    "modelr"      "purrr"      
#> [16] "readr"       "readxl\n(>=" "reprex"      "rlang"       "rstudioapi" 
#> [21] "rvest"       "stringr"     "tibble"      "tidyr"       "xml2"       
#> [26] "tidyverse"
```
Look like:

```r
tidyverse::tidyverse_packages()
#>  [1] "broom"       "cli"         "crayon"      "dplyr"       "dbplyr"     
#>  [6] "forcats"     "ggplot2"     "haven"       "hms"         "httr"       
#> [11] "jsonlite"    "lubridate"   "magrittr"    "modelr"      "purrr"      
#> [16] "readr"       "readxl" "reprex"      "rlang"       "rstudioapi" 
#> [21] "rvest"       "stringr"     "tibble"      "tidyr"       "xml2"       
#> [26] "tidyverse"
```