### PR TITLE
Add pillar 1.2.0 dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,7 +37,7 @@ Imports:
     rstudioapi (>= 0.7),
     rvest (>= 0.3.2),
     stringr (>= 1.2.0),
-    tibble (>= 1.3.4),
+    tibble (>= 1.4.2),
     tidyr (>= 0.7.2),
     xml2 (>= 1.1.1)
 Suggests: 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,7 @@ Imports:
     forcats (>= 0.2.0),
     ggplot2 (>= 2.2.1),
     haven (>= 1.1.0),
-    hms (>= 0.3),
+    hms (>= 0.4.1),
     httr (>= 1.3.1),
     jsonlite (>= 1.5),
     lubridate (>= 1.7.1),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,6 +28,7 @@ Imports:
     lubridate (>= 1.7.1),
     magrittr (>= 1.5),
     modelr (>= 0.1.1),
+    pillar (>= 1.2.0),
     purrr (>= 0.2.4),
     readr (>= 1.1.1),
     readxl (>= 1.0.0),


### PR DESCRIPTION
which is on CRAN now. This is to make sure an up-to-date version is installed, because no tibble release is planned for the updated pillar version.