### PR TITLE
Fix broken link to pkgdown site

### DIFF
--- a/docs/articles/index.html
+++ b/docs/articles/index.html
@@ -98,7 +98,7 @@
 
 <div class="author">
   <p>Developed by <a href='http://hadley.nz'>Hadley Wickham</a>, <a href='https://www.rstudio.com'><img src='http://tidyverse.org/rstudio-logo.svg' height='24' /></a>.</p>
-  <p>Site built by <a href="http://hadley.github.io/pkgdown/">pkgdown</a>.</p>
+  <p>Site built by <a href="http://pkgdown.r-lib.org/">pkgdown</a>.</p>
 </div>
 
 <script>

--- a/docs/articles/manifesto.html
+++ b/docs/articles/manifesto.html
@@ -151,7 +151,7 @@
 
 <div class="author">
   <p>Developed by <a href="http://hadley.nz">Hadley Wickham</a>, <a href="https://www.rstudio.com"><img src="http://tidyverse.org/rstudio-logo.svg" height="24"></a>.</p>
-  <p>Site built by <a href="http://hadley.github.io/pkgdown/">pkgdown</a>.</p>
+  <p>Site built by <a href="http://pkgdown.r-lib.org/">pkgdown</a>.</p>
 </div>
 
 <script>

--- a/docs/authors.html
+++ b/docs/authors.html
@@ -103,7 +103,7 @@
 
 <div class="author">
   <p>Developed by <a href='http://hadley.nz'>Hadley Wickham</a>, <a href='https://www.rstudio.com'><img src='http://tidyverse.org/rstudio-logo.svg' height='24' /></a>.</p>
-  <p>Site built by <a href="http://hadley.github.io/pkgdown/">pkgdown</a>.</p>
+  <p>Site built by <a href="http://pkgdown.r-lib.org/">pkgdown</a>.</p>
 </div>
 
 <script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -223,7 +223,7 @@ devtools::<span class="kw">install_github</span>(<span class="st">"hadley/tidyve
 
 <div class="author">
   <p>Developed by <a href="http://hadley.nz">Hadley Wickham</a>, <a href="https://www.rstudio.com"><img src="http://tidyverse.org/rstudio-logo.svg" height="24"></a>.</p>
-  <p>Site built by <a href="http://hadley.github.io/pkgdown/">pkgdown</a>.</p>
+  <p>Site built by <a href="http://pkgdown.r-lib.org/">pkgdown</a>.</p>
 </div>
 
 <script>

--- a/docs/news/index.html
+++ b/docs/news/index.html
@@ -131,7 +131,7 @@
 
 <div class="author">
   <p>Developed by <a href='http://hadley.nz'>Hadley Wickham</a>, <a href='https://www.rstudio.com'><img src='http://tidyverse.org/rstudio-logo.svg' height='24' /></a>.</p>
-  <p>Site built by <a href="http://hadley.github.io/pkgdown/">pkgdown</a>.</p>
+  <p>Site built by <a href="http://pkgdown.r-lib.org/">pkgdown</a>.</p>
 </div>
 
 <script>

--- a/docs/reference/index.html
+++ b/docs/reference/index.html
@@ -143,7 +143,7 @@
 
 <div class="author">
   <p>Developed by <a href='http://hadley.nz'>Hadley Wickham</a>, <a href='https://www.rstudio.com'><img src='http://tidyverse.org/rstudio-logo.svg' height='24' /></a>.</p>
-  <p>Site built by <a href="http://hadley.github.io/pkgdown/">pkgdown</a>.</p>
+  <p>Site built by <a href="http://pkgdown.r-lib.org/">pkgdown</a>.</p>
 </div>
 
 <script>

--- a/docs/reference/tidyverse-package.html
+++ b/docs/reference/tidyverse-package.html
@@ -126,7 +126,7 @@ Other contributors:
 
 <div class="author">
   <p>Developed by <a href='http://hadley.nz'>Hadley Wickham</a>, <a href='https://www.rstudio.com'><img src='http://tidyverse.org/rstudio-logo.svg' height='24' /></a>.</p>
-  <p>Site built by <a href="http://hadley.github.io/pkgdown/">pkgdown</a>.</p>
+  <p>Site built by <a href="http://pkgdown.r-lib.org/">pkgdown</a>.</p>
 </div>
 
 <script>

--- a/docs/reference/tidyverse_conflicts.html
+++ b/docs/reference/tidyverse_conflicts.html
@@ -120,7 +120,7 @@ existing code.</p>
 
 <div class="author">
   <p>Developed by <a href='http://hadley.nz'>Hadley Wickham</a>, <a href='https://www.rstudio.com'><img src='http://tidyverse.org/rstudio-logo.svg' height='24' /></a>.</p>
-  <p>Site built by <a href="http://hadley.github.io/pkgdown/">pkgdown</a>.</p>
+  <p>Site built by <a href="http://pkgdown.r-lib.org/">pkgdown</a>.</p>
 </div>
 
 <script>

--- a/docs/reference/tidyverse_deps.html
+++ b/docs/reference/tidyverse_deps.html
@@ -114,7 +114,7 @@ tidyverse packages.</p></td>
 
 <div class="author">
   <p>Developed by <a href='http://hadley.nz'>Hadley Wickham</a>, <a href='https://www.rstudio.com'><img src='http://tidyverse.org/rstudio-logo.svg' height='24' /></a>.</p>
-  <p>Site built by <a href="http://hadley.github.io/pkgdown/">pkgdown</a>.</p>
+  <p>Site built by <a href="http://pkgdown.r-lib.org/">pkgdown</a>.</p>
 </div>
 
 <script>

--- a/docs/reference/tidyverse_packages.html
+++ b/docs/reference/tidyverse_packages.html
@@ -120,7 +120,7 @@
 
 <div class="author">
   <p>Developed by <a href='http://hadley.nz'>Hadley Wickham</a>, <a href='https://www.rstudio.com'><img src='http://tidyverse.org/rstudio-logo.svg' height='24' /></a>.</p>
-  <p>Site built by <a href="http://hadley.github.io/pkgdown/">pkgdown</a>.</p>
+  <p>Site built by <a href="http://pkgdown.r-lib.org/">pkgdown</a>.</p>
 </div>
 
 <script>

--- a/docs/reference/tidyverse_update.html
+++ b/docs/reference/tidyverse_update.html
@@ -122,7 +122,7 @@ tidyverse packages.</p></td>
 
 <div class="author">
   <p>Developed by <a href='http://hadley.nz'>Hadley Wickham</a>, <a href='https://www.rstudio.com'><img src='http://tidyverse.org/rstudio-logo.svg' height='24' /></a>.</p>
-  <p>Site built by <a href="http://hadley.github.io/pkgdown/">pkgdown</a>.</p>
+  <p>Site built by <a href="http://pkgdown.r-lib.org/">pkgdown</a>.</p>
 </div>
 
 <script>


### PR DESCRIPTION
Closes #110 with code mod; see [primary issue](https://github.com/tidyverse/tidytemplate/pull/6#issuecomment-359265304) and similar fixes:

* https://github.com/tidyverse/tidytemplate/commit/5ca9e91e656b46221d5427e3a94805b395807d73
* https://github.com/tidyverse/dplyr/commit/3f62f3bae984f2e8dbab64853ee316bbec1c9d96
* https://github.com/tidyverse/reprex/commit/5a37f5962e72054bce244f17d5a728610bdcc349