### PR TITLE
Return 0 version for non-existing dependency package 

### DIFF
--- a/R/update.R
+++ b/R/update.R
@@ -52,7 +52,7 @@ tidyverse_deps <- function(recursive = FALSE) {
   )
   pkg_deps <- setdiff(pkg_deps, base_pkgs)
 
-  pkg_installed <- rownames(installed.packages())
+  pkg_installed <- rownames(utils::installed.packages())
   cran_version <- lapply(pkgs[pkg_deps, "Version"], base::package_version)
   local_version <- lapply(pkg_deps, function(x) {
     if (x %in% pkg_installed) {

--- a/R/update.R
+++ b/R/update.R
@@ -52,8 +52,15 @@ tidyverse_deps <- function(recursive = FALSE) {
   )
   pkg_deps <- setdiff(pkg_deps, base_pkgs)
 
+  pkg_installed <- rownames(installed.packages())
   cran_version <- lapply(pkgs[pkg_deps, "Version"], base::package_version)
-  local_version <- lapply(pkg_deps, utils::packageVersion)
+  local_version <- lapply(pkg_deps, function(x) {
+    if (x %in% pkg_installed) {
+      utils::packageVersion(x)
+    } else {
+      0
+    }
+  })
 
   behind <- purrr::map2_lgl(cran_version, local_version, `>`)
 


### PR DESCRIPTION
If any of the dependency packages is removed (`tidyverse_deps(TRUE)` or `tidyverse_update(TRUE)`) would fail. This happens because `utils::packageVersion` returns error (`NA` result from `packageDescription`).  

To fix this issue we can check if dependency is within `installed.packages()` and if not return `0` so that comparison between package version with CRAN would work.

Example:
```
utils::remove.packages("selectr")
tidyverse::tidyverse_deps() # works
tidyverse::tidyverse_deps(TRUE) # returns: Error in FUN(X[[i]], ...) : package ‘selectr’ not found
```

PS. This would not happen if any of  `tidyverse` packages is missing as the `library(tidyverse)` wouldn't work.
