### PR TITLE
Remove core_loaded() (used nowhere)

### DIFF
--- a/R/attach.R
+++ b/R/attach.R
@@ -1,9 +1,5 @@
 core <- c("ggplot2", "tibble", "tidyr", "readr", "purrr", "dplyr", "stringr", "forcats")
 
-core_loaded <- function() {
-  search <- paste0("package:", core)
-  core[search %in% search()]
-}
 core_unloaded <- function() {
   search <- paste0("package:", core)
   core[!search %in% search()]


### PR DESCRIPTION
Maybe `core_loaded()` is here for convenience but it seems dead code. Searching commits on attach.R I see that `core_loaded()` appears in SHA 8c7cffba but was never used.