### PR TITLE
Attach packages from same lib they were loaded from

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # tidyverse 1.2.1.9000
 
+* Packages attached from same library they were initially loaded from 
+  (#171, @gabrocsardi)
+
 * If conflicted package is loaded, omit display of conflicts
 
 * Eliminate repeats in the package list when loading an odd number of packages (#94, #100, @dchiu911)

--- a/R/attach.R
+++ b/R/attach.R
@@ -9,6 +9,15 @@ core_unloaded <- function() {
   core[!search %in% search()]
 }
 
+## Attach the package from the same package library it was
+## loaded from before. https://github.com/tidyverse/tidyverse/issues/171
+
+same_library <- function(pkg) {
+  loc <- if (pkg %in% loadedNamespaces()) dirname(getNamespaceInfo(pkg, "path"))
+  do.call(
+    "library",
+    list(pkg, lib.loc = loc, character.only = TRUE, warn.conflicts = FALSE))
+}
 
 tidyverse_attach <- function() {
   to_load <- core_unloaded()
@@ -38,7 +47,7 @@ tidyverse_attach <- function() {
   msg(paste(info, collapse = "\n"), startup = TRUE)
 
   suppressPackageStartupMessages(
-    lapply(to_load, library, character.only = TRUE, warn.conflicts = FALSE)
+    lapply(to_load, same_library)
   )
 
   invisible()

--- a/R/attach.R
+++ b/R/attach.R
@@ -9,14 +9,14 @@ core_unloaded <- function() {
   core[!search %in% search()]
 }
 
-## Attach the package from the same package library it was
-## loaded from before. https://github.com/tidyverse/tidyverse/issues/171
-
+# Attach the package from the same package library it was
+# loaded from before. https://github.com/tidyverse/tidyverse/issues/171
 same_library <- function(pkg) {
   loc <- if (pkg %in% loadedNamespaces()) dirname(getNamespaceInfo(pkg, "path"))
   do.call(
     "library",
-    list(pkg, lib.loc = loc, character.only = TRUE, warn.conflicts = FALSE))
+    list(pkg, lib.loc = loc, character.only = TRUE, warn.conflicts = FALSE)
+  )
 }
 
 tidyverse_attach <- function() {


### PR DESCRIPTION
Otherwise install.packages() test loading might run
into trouble, if the package versions are different,
and (in some way) incompatible.

Closes #171.