### PR TITLE
improve function tidyverse_packages() to get right output

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -33,8 +33,9 @@ text_col <- function(x) {
 tidyverse_packages <- function(include_self = TRUE) {
   raw <- utils::packageDescription("tidyverse")$Imports
   imports <- strsplit(raw, ",")[[1]]
-  parsed <- gsub("^\\s+|\\s+$", "", imports)
-  names <- vapply(strsplit(parsed, "\\s+"), "[[", 1, FUN.VALUE = character(1))
+  parsed <- gsub("\\n", "", imports)
+  parsed <- gsub("(\\(.*?\\))", "", parsed)
+  names <- gsub("^\\s+|\\s+$", "", parsed)
 
   if (include_self) {
     names <- c(names, "tidyverse")


### PR DESCRIPTION
This PR fixs the parse error like **readxl\n(>=**, related to https://github.com/tidyverse/tidyverse/issues/186

``` r
tidyverse::tidyverse_packages()
#>  [1] "broom"       "cli"         "crayon"      "dplyr"       "dbplyr"     
#>  [6] "forcats"     "ggplot2"     "haven"       "hms"         "httr"       
#> [11] "jsonlite"    "lubridate"   "magrittr"    "modelr"      "purrr"      
#> [16] "readr"       "readxl\n(>=" "reprex"      "rlang"       "rstudioapi" 
#> [21] "rvest"       "stringr"     "tibble"      "tidyr"       "xml2"       
#> [26] "tidyverse"
```

<sup>Created on 2019-07-03 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>
