### PR TITLE
Honor Config/Needs/website (and don't cache pak)

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -24,14 +24,14 @@ jobs:
       - name: Install pak and query dependencies
         run: |
           install.packages("pak", repos = "https://r-lib.github.io/p/pak/dev/")
-          saveRDS(pak::pkg_deps("local::.", dependencies = TRUE), ".github/r-depends.rds")
+          saveRDS(pak::pkg_deps("local::.", dependencies = c("all", "Config/Needs/website")), ".github/r-depends.rds")
         shell: Rscript {0}
 
       - name: Restore R package cache
         uses: actions/cache@v2
         with:
           path: |
-            ${{ env.R_LIBS_USER }}
+            ${{ env.R_LIBS_USER }}/*
             !${{ env.R_LIBS_USER }}/pak
           key: ubuntu-18.04-${{ steps.install-r.outputs.installed-r-version }}-2-${{ hashFiles('.github/r-depends.rds') }}
           restore-keys: ubuntu-18.04-${{ steps.install-r.outputs.installed-r-version }}-2-


### PR DESCRIPTION
Maybe this will fix pkgdown? But we won't be able to tell because current pkgdown workflow doesn't build for PRs.