### PR TITLE
Fix typo in documentation

### DIFF
--- a/R/update.R
+++ b/R/update.R
@@ -67,7 +67,7 @@ tidyverse_sitrep <- function() {
 #' @param recursive If \code{TRUE}, will also list all dependencies of
 #'   tidyverse packages.
 #' @param repos The repositories to use to check for updates.
-#'   Defaults to \code{getOptions("repos")}.
+#'   Defaults to \code{getOption("repos")}.
 #' @export
 tidyverse_deps <- function(recursive = FALSE, repos = getOption("repos")) {
   pkgs <- utils::available.packages(repos = repos)

--- a/man/tidyverse_deps.Rd
+++ b/man/tidyverse_deps.Rd
@@ -11,7 +11,7 @@ tidyverse_deps(recursive = FALSE, repos = getOption("repos"))
 tidyverse packages.}
 
 \item{repos}{The repositories to use to check for updates.
-Defaults to \code{getOptions("repos")}.}
+Defaults to \code{getOption("repos")}.}
 }
 \description{
 List all tidyverse dependencies

--- a/man/tidyverse_update.Rd
+++ b/man/tidyverse_update.Rd
@@ -11,7 +11,7 @@ tidyverse_update(recursive = FALSE, repos = getOption("repos"))
 tidyverse packages.}
 
 \item{repos}{The repositories to use to check for updates.
-Defaults to \code{getOptions("repos")}.}
+Defaults to \code{getOption("repos")}.}
 }
 \description{
 This will check to see if all tidyverse packages (and optionally, their


### PR DESCRIPTION
In the documentation for `tidyverse_deps()` and `tidyverse_update()`, the `repos` argument is described as defaulting to `getOptions("repos")` (note the 's'), which doesn't exist, instead of `getOption("repos")`.