### PR TITLE
Update README.md - pak:system_requirements() is deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ pak::pak("tidyverse/tidyverse")
 </div>
 
 If you’re compiling from source, you can run
-`pak::pkg_system_requirements("tidyverse")`, to see the complete set of
+`pak::pkg_sysreqs('tidyverse')`, to see the complete set of
 system packages needed on your machine.
 
 ## Usage


### PR DESCRIPTION
When I tried to run system_requirements(), I got
```
> pak::pkg_system_requirements("tidyverse")
`pak::pkg_system_requirements()` is deprecated since pak 0.6.0.
Please use `pak::pkg_sysreqs()` instead.
```
I installed `pak` from CRAN. 

In case my local environment matters:

```
> sessionInfo()
R version 4.3.1 (2023-06-16)
Platform: x86_64-apple-darwin20 (64-bit)
Running under: macOS Sonoma 14.0

Matrix products: default
BLAS:   /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libBLAS.dylib 
LAPACK: /Library/Frameworks/R.framework/Versions/4.3-x86_64/Resources/lib/libRlapack.dylib;  LAPACK version 3.11.0

locale:
[1] en_US.UTF-8/en_US.UTF-8/en_US.UTF-8/C/en_US.UTF-8/en_US.UTF-8

time zone: America/New_York
tzcode source: internal

attached base packages:
[1] stats     graphics  grDevices utils     datasets  methods   base     

other attached packages:
[1] pak_0.6.0

loaded via a namespace (and not attached):
 [1] Matrix_1.6-1.1     gtable_0.3.4       dplyr_1.1.3        compiler_4.3.1    
 [5] tidyselect_1.2.0   stringr_1.5.0      callr_3.7.3        tidyr_1.3.0       
 [9] splines_4.3.1      scales_1.2.1       yaml_2.3.7         fastmap_1.1.1     
[13] ggforestplot_0.1.0 lattice_0.21-9     ggplot2_3.4.3      R6_2.5.1          
[17] pak_0.6.0          generics_0.1.3     knitr_1.44         backports_1.4.1   
[21] tibble_3.2.1       munsell_0.5.0      pillar_1.9.0       rlang_1.1.1       
[25] utf8_1.2.3         broom_1.0.5        stringi_1.7.12     xfun_0.40         
[29] lazyeval_0.2.2     cli_3.6.1          magrittr_2.0.3     ps_1.7.5          
[33] processx_3.8.2     digest_0.6.33      grid_4.3.1         rstudioapi_0.15.0 
[37] lifecycle_1.0.3    vctrs_0.6.3        evaluate_0.22      glue_1.6.2        
[41] sessioninfo_1.2.2  survival_3.5-7     fansi_1.0.4        colorspace_2.1-0  
[45] rmarkdown_2.25     purrr_1.0.2        tools_4.3.1        pkgconfig_2.0.3   
[49] htmltools_0.5.6  
```