### PR TITLE
Improve organization of .onAttach

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,13 +1,17 @@
 .onAttach <- function(...) {
-  if (!is_loading_for_tests()) {
-    attached <- tidyverse_attach()
-    inform_startup(tidyverse_attach_message(attached))
+  if (is_loading_for_tests()) {
+    return(invisible())
   }
 
-  if (!is_attached("conflicted") && !is_loading_for_tests()) {
-    conflicts <- tidyverse_conflicts()
-    inform_startup(tidyverse_conflict_message(conflicts))
+  attached <- tidyverse_attach()
+  inform_startup(tidyverse_attach_message(attached))
+
+  if (is_attached("conflicted")) {
+    return(invisible())
   }
+
+  conflicts <- tidyverse_conflicts()
+  inform_startup(tidyverse_conflict_message(conflicts))
 }
 
 is_attached <- function(x) {

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,6 +1,6 @@
 .onAttach <- function(...) {
-  attached <- tidyverse_attach()
   if (!is_loading_for_tests()) {
+    attached <- tidyverse_attach()
     inform_startup(tidyverse_attach_message(attached))
   }
 


### PR DESCRIPTION
Originally spotted that `attached` is not needed outside the `!is_loading_for_tests()` branch, then landed on early returns to improve the flow.